### PR TITLE
Add new rule for new URL()

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,47 @@ try {
 ```
 
 If you are confident that the `JSON.parse` will not throw an error, you can disable this rule.
+
+### try-catch-failsafe/new-url
+
+- **Default**: `error`
+- **Fixable**: `false`
+
+Make sure to use try-catch to wrap up `new URL()`. Notice that the `new URL()` in `catch` or `finally` block may also throw an error in JavaScript, so we should wrap them up too.
+
+```js
+// ❌ Error
+new URL('');
+
+// ❌ Error
+try {
+  // some code that may throw an error
+} catch (e) {
+  new URL('');
+}
+
+// ❌ Error
+try {
+  // some code that may throw an error
+} finally {
+  new URL('');
+}
+
+// ✅ OK
+try {
+  new URL('');
+} catch (e) {
+  console.error(e);
+}
+
+// ✅ OK
+try {
+  // some code that may throw an error
+} finally {
+  try {
+    new URL('');
+  } finally {}
+}
+```
+
+If you are confident that the `new URL()` will not throw an error, you can disable this rule.

--- a/src/rules/new-url.ts
+++ b/src/rules/new-url.ts
@@ -1,0 +1,64 @@
+import type { Rule } from 'eslint';
+import type * as ESTree from 'estree';
+
+const findTryStatementRange = (
+  node: ESTree.Node & Partial<Rule.NodeParentExtension>,
+): [number, number] | null => {
+  if (!node.parent) {
+    return null;
+  }
+  if (node.parent.type === 'TryStatement') {
+    /**
+     * The `try` statement should not be the only condition to determine
+     * whether the `new URL()` call is wrapped in `try-catch` block,
+     * because the following code will not throw an error in JavaScript:
+     *
+     * ```js
+     * try {
+     *   // some code that throws an error
+     * } catch {
+     *   new URL('');
+     * } finally {
+     *   new URL('');
+     * }
+     *
+     * So if node is wrapped in `catch` or `finally` block, we shoud
+     * still report the error.
+     */
+    if (node.parent?.handler === node || node.parent?.finalizer === node) {
+      return null;
+    }
+    return node.range;
+  }
+  return findTryStatementRange(node.parent);
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Use try-catch to wrap new URL()',
+    },
+    fixable: null,
+    messages: {
+      shouldWrap: 'new URL() should be wrapped in try-catch',
+    },
+  },
+  create: (context: Rule.RuleContext): Rule.RuleListener => {
+    return {
+      NewExpression: node => {
+        if (node.callee.type === 'Identifier' && node.callee.name === 'URL') {
+          const range = findTryStatementRange(node);
+          if (!range) {
+            context.report({ node, messageId: 'shouldWrap' });
+            return;
+          }
+          // range should be bigger than node.range
+          if (range[0] < node.range[0] && node.range[1] < range[1]) {
+            return;
+          }
+          context.report({ node, messageId: 'shouldWrap' });
+        }
+      },
+    };
+  },
+};

--- a/tests/rules/new-url.spec.ts
+++ b/tests/rules/new-url.spec.ts
@@ -1,0 +1,103 @@
+import eslint from 'eslint';
+
+const ruleTester = new eslint.RuleTester({
+  parserOptions: { ecmaVersion: 10 },
+});
+
+const rule = require('../../src/rules/new-url');
+
+ruleTester.run("json-parse-in-try-catch", rule, {
+  valid: [
+    {
+      code: `
+        try {
+          new URL('');
+        } catch(err) {}
+      `,
+    },
+    {
+      // new syntax (no params in `catch` block)
+      code: `
+        try {
+          new URL('');
+        } catch {}
+      `,
+    },
+    {
+      // new syntax (no `catch` block)
+      code: `
+        try {
+          new URL('');
+        } finally {}
+      `,
+    },
+    {
+      code: `
+        let a = null;
+        try {
+          a = new URL('');
+        } catch(err) {}
+      `,
+    },
+    {
+      // new URL() in `finally` block, but it's wrapped again
+      code: `
+        let a = null;
+        try {
+        } finally {
+          try {
+            a = new URL('');
+          } finally {}
+        }
+      `,
+    },
+    {
+      // no new URL() at all
+      code: `
+        console.log('ok');
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        const b = new URL('');
+      `,
+      errors: [
+        { messageId: 'shouldWrap', type: 'NewExpression' },
+      ],
+    },
+    {
+      code: `
+        new URL('');
+      `,
+      errors: [
+        { messageId: 'shouldWrap', type: 'NewExpression' },
+      ],
+    },
+    {
+      code: `
+        try {
+          /**/
+        } catch {
+          new URL('');
+        }
+      `,
+      errors: [
+        { messageId: 'shouldWrap', type: 'NewExpression' },
+      ],
+    },
+    {
+      code: `
+        try {
+          /**/
+        } finally {
+          new URL('');
+        }
+      `,
+      errors: [
+        { messageId: 'shouldWrap', type: 'NewExpression' },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
According to the rule of `JSON.parse`, I added a rule for `new URL()`. 